### PR TITLE
Add builder for `arm64` image

### DIFF
--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -8,9 +8,6 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-  pull_request:
-    branches:
-      - '**'
 
 jobs:
   push_to_registry:
@@ -36,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: dbut2/spanner-emulator
+          images: roryq/spanner-emulator
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: roryq/spanner-emulator
+          images: dbut2/spanner-emulator
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -8,6 +8,9 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add platform field to docker build and push action, includes arm64 as well as default amd64 previously used

Tested in fork, action builds and pushes successfully

Dockerhub showins tag with multiple platforms
<img width="1200" alt="Screen Shot 2022-03-01 at 3 11 48 pm" src="https://user-images.githubusercontent.com/61171623/156103430-a86f8310-9636-4600-b1c0-b33ad08fe466.png">

Docker pull --platform X pulls image as required
```sh
$ docker pull dbut2/spanner-emulator:pr-1 --platform linux/amd64
...
docker.io/dbut2/spanner-emulator:pr-1
$ docker inspect dbut2/spanner-emulator:pr-1 | grep Arch        
        "Architecture": "amd64",


$ docker pull dbut2/spanner-emulator:pr-1 --platform linux/arm64
...
docker.io/dbut2/spanner-emulator:pr-1
$ docker inspect dbut2/spanner-emulator:pr-1 | grep Arch        
        "Architecture": "arm64",
```